### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/beoplay/manifest.json
+++ b/custom_components/beoplay/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "beoplay",
   "name": "BeoPlay",
+  "version": "0.1",
   "documentation": "https://github.com/martonborzak/beoplay-custom-component",
   "dependencies": [],
   "codeowners": [],


### PR DESCRIPTION
Fix the error: No 'version' key in the manifest file for custom integration 'beoplay'. As of Home Assistant 2021.6, this integration will no longer be loaded.